### PR TITLE
Max Datom - Level 12: :xform option.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"
-         "src/resources"]
+         "resources"]
  :deps {;; https://docs.datomic.com/on-prem/peer/integrating-peer-lib.html
         com.datomic/datomic-pro {:mvn/version "1.0.6397"}
         ;; + datomic client library: api: https://docs.datomic.com/on-prem/client/integrating-client-lib.html

--- a/resources/datomic/extensions.edn
+++ b/resources/datomic/extensions.edn
@@ -1,0 +1,1 @@
+{:xforms [maxdatom.level-12/comment-count-str]}

--- a/src/max_datom/level_12.clj
+++ b/src/max_datom/level_12.clj
@@ -1,0 +1,33 @@
+(ns maxdatom.level-12
+  "https://max-datom.com/#/4EC4A43A-698E-4240-9E5E-9A9C36C93673
+  :xform option: https://docs.datomic.com/cloud/query/query-pull.html#xform-option
+  - see also onprem docs: https://docs.datomic.com/on-prem/query/pull.html#xform
+  "
+  (:require
+   [datomic.api :as d]
+   [max-datom.connections :refer [db]]))
+
+
+(defn comment-count-str [x]
+  (str "Comment Count: " (count x)))
+
+;; the original query
+(comment
+  (d/q '[:find  (pull ?posts [{:post/author [:user/first+last-name]}])
+         :where [?posts :post/author _]]
+       (db))
+  ;; => [[#:post{:author #:user{:first+last-name ["E. L." "Mainframe"]}}]
+  ;;     [#:post{:author #:user{:first+last-name ["E. L." "Mainframe"]}}]
+  ;;     [#:post{:author #:user{:first+last-name ["E. L." "Mainframe"]}}]
+  ;;     [#:post{:author #:user{:first+last-name ["Segfault" "Larsson"]}}]]
+  .)
+
+;; modify the query to return the post author
+;; and a string "Comment Count: <count>" (for :post/comments)
+(comment
+  (d/q '[:find  (pull ?posts [{:post/author [:user/first+last-name]}
+                              [:post/comments :xform comment-count-str]])
+         :where [?posts :post/author _]]
+       (db))
+  
+  .)

--- a/src/max_datom/level_12.clj
+++ b/src/max_datom/level_12.clj
@@ -26,8 +26,11 @@
 ;; and a string "Comment Count: <count>" (for :post/comments)
 (comment
   (d/q '[:find  (pull ?posts [{:post/author [:user/first+last-name]}
-                              [:post/comments :xform comment-count-str]])
+                              [:post/comments :xform maxdatom.level-12/comment-count-str]])
          :where [?posts :post/author _]]
        (db))
-  
+  ;; => [[#:post{:author #:user{:first+last-name ["E. L." "Mainframe"]}, :comments "Comment Count: 3"}]
+  ;;     [#:post{:author #:user{:first+last-name ["E. L." "Mainframe"]}, :comments "Comment Count: 2"}]
+  ;;     [#:post{:author #:user{:first+last-name ["E. L." "Mainframe"]}, :comments "Comment Count: 0"}]
+  ;;     [#:post{:author #:user{:first+last-name ["Segfault" "Larsson"]}, :comments "Comment Count: 2"}]]
   .)


### PR DESCRIPTION
See the docs: https://docs.datomic.com/on-prem/query/pull.html#xform

This discussion is also useful: https://forum.datomic.com/t/pull-xform-extensions/1525/2
See how you need to add datomic/extensions.edn to your app classpath,
not Datomic's transaction.

The query:
```
  (d/q '[:find  (pull ?posts [{:post/author [:user/first+last-name]}
                              [:post/comments :xform maxdatom.level-12/comment-count-str]])
         :where [?posts :post/author _]]
       (db))
```

This is the error you'll see if the `:xforms` option isn't configured properly or if you don't use **fully-qualified function name** inside the `:find` clause - see also https://www.reddit.com/r/Clojure/comments/tw66df/comment/i3kldxb/.
```
1. Caused by clojure.lang.ExceptionInfo
   'comment-count-str' needs to be listed under :xforms in datomic/extensions.edn
   #:cognitect.anomalies{:category :cognitect.anomalies/forbidden,
                         :message
                         "'comment-count-str' needs to be listed under :xforms in datomic/extensions.edn"}
    extension_resolver.clj:   24  datomic.extension-resolver/anomaly!
    extension_resolver.clj:   22  datomic.extension-resolver/anomaly!
    extension_resolver.clj:  113  datomic.extension-resolver/resolve!
    extension_resolver.clj:  103  datomic.extension-resolver/resolve!
    extension_resolver.clj:  125  datomic.extension-resolver/resolve-xform!
...
```